### PR TITLE
Wok 730 pvica thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.6 (2023-06-29)
+===
+
+*Unreleased*
+Add support for Preservica resource IDs, which are just raw UUIDs in standard hex representation, without any pre- or post-fix
+Add check for successful regexp matching in CheckTIcket.pmas the result $1 is set previously in check.pl and non-matching keeps the old $1 value. This previously caused successful checks for invalid IDs
+
+
 0.5
 ===
 

--- a/create-deployment-targz.sh
+++ b/create-deployment-targz.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR=newspaper-fastcgi-ticket-checker-$(head -n 1 CHANGELOG.md)
+DIR=newspaper-fastcgi-ticket-checker-$(grep -m 1 -o "^[0-9.]\+" CHANGELOG.md)
 
 mkdir -p tmp
 tar cvzf tmp/${DIR}.tgz "--transform=s_^_${DIR}/_" CHANGELOG.md fcgid-access-checker/

--- a/fcgid-access-checker/CheckTicket.pm
+++ b/fcgid-access-checker/CheckTicket.pm
@@ -128,8 +128,8 @@ sub logUsageStatisticsAndReturnStatusCodeFor {
 
         # Fail if the requested resource uuid is not one of the
         # resources described in the ticket.
-        # doms_radioTVCollection:uuid:853a0b31-c944-44a5-8e42-bc9b5bc697be
-
+        # DOMS record ID:         doms_radioTVCollection:uuid:853a0b31-c944-44a5-8e42-bc9b5bc697be
+        # Preservica resource ID: 1bee2176-9f62-4f66-9854-ee0e61724359
         my $found = $FALSE;
 
         # (Note: Array regexp requires perl 5.10 and is experimental,
@@ -137,7 +137,7 @@ sub logUsageStatisticsAndReturnStatusCodeFor {
 
         for my $resource (@resources) {
             # http://stackoverflow.com/a/6640851/53897
-            $resource =~ m/uuid:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/;
+            $resource =~ m/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/;
             if ($1 eq $requested_resource) {
                 $found = $TRUE;
                 last;

--- a/fcgid-access-checker/CheckTicket.pm
+++ b/fcgid-access-checker/CheckTicket.pm
@@ -137,10 +137,11 @@ sub logUsageStatisticsAndReturnStatusCodeFor {
 
         for my $resource (@resources) {
             # http://stackoverflow.com/a/6640851/53897
-            $resource =~ m/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/;
-            if ($1 eq $requested_resource) {
-                $found = $TRUE;
-                last;
+            if ( $resource =~ m/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/ ) {
+                if ($1 eq $requested_resource) {
+                    $found = $TRUE;
+                    last;
+                }
             }
         }
         if ($found == $FALSE) {


### PR DESCRIPTION
This pull request aims to fix part of a problem in Mediestream where TV thumbnails are unreliable for Preservica records.

* Add support for Preservica resource IDs, which are just raw UUIDs in standard hex representation, without any pre- or post-fix
* Add check for successful regexp matching in `CheckTIcket.pm`as the result `$1` is set previously in `check.pl` and non-matching keeps the old `$1` value. This previously caused successful checks for invalid IDs